### PR TITLE
Use impretive implementation to support default values

### DIFF
--- a/src/ReqHooksConfig.js
+++ b/src/ReqHooksConfig.js
@@ -1,3 +1,5 @@
+import { useParam, useQuery, useHeader } from './ReqHooksImplementation';
+
 export default {
 	baseUrl: 'useBaseUrl',
 	path: 'usePath',
@@ -6,7 +8,7 @@ export default {
 	fresh: 'useIsFresh',
 	stale: 'useIsStale',
 	header: {
-		type: 'function',
+		implementation: useHeader,
 		name: 'useHeader',
 	},
 	accepts: {
@@ -38,11 +40,11 @@ export default {
 		name: 'useIsLanguageAcceptable',
 	},
 	query: {
-		type: 'object',
+		implementation: useQuery,
 		name: 'useQuery',
 	},
 	params: {
-		type: 'object',
+		implementation: useParam,
 		name: 'useParam',
 	},
 	// range: 'useRange',

--- a/src/ReqHooksImplementation.js
+++ b/src/ReqHooksImplementation.js
@@ -1,0 +1,11 @@
+export function useParam(req, description, [paramName, defaultValue]) {
+	return req.params[paramName] || defaultValue;
+}
+
+export function useQuery(req, description, [queryName, defaultValue]) {
+	return req.query[queryName] || defaultValue;
+}
+
+export function useHeader(req, description, [headerName, defaultValue]) {
+	return req.get(headerName) || defaultValue;
+}

--- a/src/ResHooksConfig.js
+++ b/src/ResHooksConfig.js
@@ -1,3 +1,5 @@
+import { useResponseHeader } from './ResHooksImplementation';
+
 module.exports = {
 	cookie: {
 		type: 'function',
@@ -12,7 +14,7 @@ module.exports = {
 		name: 'useAttachment',
 	},
 	get: {
-		type: 'function',
+		implementation: useResponseHeader,
 		name: 'useResponseHeader',
 	},
 };

--- a/src/ResHooksImplementation.js
+++ b/src/ResHooksImplementation.js
@@ -1,0 +1,3 @@
+export function useResponseHeader(res, description, [headerName, defaultValue]) {
+	return res.get(headerName) || defaultValue;
+}

--- a/src/__tests__/hooks.test.js
+++ b/src/__tests__/hooks.test.js
@@ -57,7 +57,7 @@ describe('hooks', () => {
 			expect(useParam('name')).toMatch('Eddie');
 		});
 
-		it.skip("Returns the default value if the specified param doesn't exist", () => {
+		it("Returns the default value if the specified param doesn't exist", () => {
 			expect(useParam('Hello', 'Cooro')).toMatch('Cooro');
 		});
 	});
@@ -98,7 +98,7 @@ describe('hooks', () => {
 			expect(useQuery('name')).toBe('eddie');
 		});
 
-		it.skip("Returns default value if the query doesn't exist", () => {
+		it("Returns default value if the query doesn't exist", () => {
 			expect(useQuery('lastName', 'cooro')).toBe('cooro');
 		});
 	});
@@ -168,19 +168,19 @@ describe('hooks', () => {
 	});
 
 	describe('useHeader', () => {
-		it('Calls req.header with the provided header name', () => {
+		it('Calls req.get with the provided header name', () => {
 			const headerName = 'HEADER';
 			const headerValue = 'VALUE';
 
-			const headerFN = jest.fn(() => headerValue);
-			setDispatcher({ _req: { header: headerFN } });
+			const getFN = jest.fn(() => headerValue);
+			setDispatcher({ _req: { get: getFN } });
 
 			expect(useHeader(headerName)).toBe(headerValue);
-			expect(headerFN).toHaveBeenCalledTimes(1);
-			expect(headerFN).toHaveBeenCalledWith(headerName);
+			expect(getFN).toHaveBeenCalledTimes(1);
+			expect(getFN).toHaveBeenCalledWith(headerName);
 		});
 
-		it.skip("Returns default value if the header doesn't exist", () => {
+		it("Returns default value if the header doesn't exist", () => {
 			const defaultValue = 'default';
 			setDispatcher({ _req: { get: () => {} } });
 			expect(useHeader('HEADER', defaultValue)).toBe(defaultValue);
@@ -200,7 +200,7 @@ describe('hooks', () => {
 			expect(getFN).toHaveBeenCalledWith(headerName);
 		});
 
-		it.skip("Returns default value if the header doesn't exist", () => {
+		it("Returns default value if the header doesn't exist", () => {
 			const defaultValue = 'default';
 			setDispatcher({ _res: { get: () => {} } });
 			expect(useResponseHeader('HEADER', defaultValue)).toBe(defaultValue);
@@ -240,8 +240,6 @@ describe('hooks', () => {
 			expect(acceptsFN).toHaveBeenCalledWith(charset);
 		});
 	});
-
-	describe.skip('useIsCharsetsAcceptable', () => {});
 
 	describe('useIsEncodingAcceptable', () => {
 		it('Calls req.acceptsEncoding with the provided parameters', () => {


### PR DESCRIPTION
I'm thinking of a better workaround (at least less repetative)
by seperating the generateHookImplementation which creates a function
from actuall object field access.
By doing this we will be able to reuse the field access in the
implementations

Resolves #41